### PR TITLE
receiver_email and amount are deprecated now.

### DIFF
--- a/api.yml
+++ b/api.yml
@@ -9,8 +9,8 @@ bonuses:
     give:
         method: POST
         path: bonuses
-        required: [ receiver_email, reason, amount ]
-        optional: [ giver_email, parent_bonus_id ]
+        required: [ reason ]
+        optional: [ giver_email, parent_bonus_id, receiver_email, amount ]
 users:
     list:
         path: users


### PR DESCRIPTION
It is now preferred to specify these as part of the 'reason'.
